### PR TITLE
[useradd_change] Simplified withour -r (system) so we get same uid as on other images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ ENV PATH /usr/bin:$PATH
 RUN chmod 1777 /tmp
 # create a special user to run code
 # user without root privileges greatly improves security
-RUN groupadd -r syncano && useradd -r -g syncano syncano
+RUN useradd syncano -d /tmp -s /bin/bash
 USER syncano


### PR DESCRIPTION
Group is automatically added anyway.
I need this change for different way of running codeboxes as currently UID of syncano in baseimage is 1000 (as expected) but all codeboxes use 999 UID (as it's a system account for some reason) and this is causing some permission issues with mounted directories.
Otherwise it is backwards compatible with what we got.
